### PR TITLE
Updated the README to reflect the ownCloud Antora build better

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3,11 +3,9 @@
 :experimental:
 :hide-uri-scheme:
 // Project URIs:
-:uri-project: https://gitlab.com/antora/antora-ui-default
-:uri-preview: https://antora.gitlab.io/antora-ui-default
-:uri-ci-pipelines: {uri-project}/pipelines
-:img-ci-status: {uri-project}/badges/master/pipeline.svg
+:uri-project: https://github.com/settermjd/docs-ui
 // External URIs:
+:uri-antora-default-ui: https://gitlab.com/antora/antora-ui-default
 :uri-antora: https://antora.org
 :uri-git: https://git-scm.com
 :uri-git-dl: {uri-git}/downloads
@@ -18,27 +16,22 @@
 :uri-nvm-install: {uri-nvm}#installation
 :uri-yarn: https://yarnpkg.com
 
-image:{img-ci-status}[CI Status (GitLab CI), link={uri-ci-pipelines}]
 
-This project is an archetype that demonstrates how to produce a UI bundle for use in a documentation site generated with {uri-antora}[Antora].
-You can see a preview of the default UI at {uri-preview}.
+This project is a custom version of {uri-antora-default-ui}[the Antora Default UI], for the Antora version of the ownCloud documentation.
 
-== Use the Default UI
+== Use the Theme
 
-If you want to use the default UI for your Antora-generated site, add the following UI configuration to your playbook:
+To use the theme with the ownCloud Antora docs, add the following UI configuration to your playbook:
 
 [source,yaml,subs=attributes+]
 ----
 ui:
-  bundle: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/master/raw/build/ui-bundle.zip?job=bundle-stable
+  bundle: https://github.com/settermjd/docs-ui/-/jobs/artifacts/master/raw/build/ui-bundle.zip?job=bundle-stable
 ----
-
-Read on to learn how to use your own build of the default UI.
 
 == Quickstart
 
-This section offers a basic tutorial for learning how to preview the default UI and bundle it for use with Antora.
-A more comprehensive tutorial will be made available in the documentation.
+This section offers a basic tutorial for learning how to preview the theme and bundle it for use with the ownCloud Antora docs.
 
 === Prerequisites
 
@@ -66,7 +59,7 @@ Next, make sure that you have Node 8 installed.
 If this command fails with an error, you don't have Node installed.
 If the command doesn't report a Node 8 version (e.g., v8.9.4), you don't have a suitable version of Node installed.
 
-While you can install Node from the official packages, we strongly recommend that you use {uri-nvm}[nvm] (Node Version Manager) to install and manage Node.
+While you can install Node from the official packages, we strongly recommend that you use {uri-nvm}[nvm] (_Node Version Manager_) to install and manage Node.
 Follow the {uri-nvm-install}[nvm installation instructions] to set up nvm on your machine.
 
 Once you've installed nvm, open a new terminal and install Node 8 using the following command:
@@ -110,7 +103,7 @@ Clone the default UI project using git:
  $ git clone {uri-project} &&
    cd "`basename $_`"
 
-The example above clones Antora's default UI project and then switches to the project folder on your filesystem.
+The example above clones the custom Antora ownCloud UI theme and then switches to the project folder on your filesystem.
 Stay in this project folder in order to initialize the project using Yarn.
 
 Use Yarn to install the project's dependencies.


### PR DESCRIPTION
My main intent here was to, where relevant, replace references to Antora with ownCloud so that it's clear that this isn't the original README or project. That said, I've left the majority of the documentation in place.